### PR TITLE
feat: enforce unique normalized knowledge base questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# Axonic-Assistant1
+# Axonic Assistant Knowledge Base
+
+Este repositorio incluye el esquema de Supabase y los scripts necesarios para mantener la tabla `public.knowledge_base` libre de duplicados gracias a una columna generada que normaliza las preguntas.
+
+## ¿Por dónde empezar?
+
+1. **Revisar el esquema.** Abre [`supabase/schema.sql`](supabase/schema.sql) y confirma que la columna generada `question_normalized` y la `UNIQUE constraint` `knowledge_base_question_key` están presentes. Si estás creando el proyecto desde cero, ejecuta el archivo completo contra tu base de datos de Supabase/Postgres:
+   ```bash
+   sudo -u postgres psql -d axonic -f supabase/schema.sql
+   ```
+
+2. **Aplicar la migración en un proyecto existente.** Si el proyecto ya está creado, vuelve a ejecutar solo la sección de `ALTER TABLE` para garantizar que la columna y la constraint existan sin tocar los datos existentes:
+   ```sql
+   alter table public.knowledge_base
+       add column if not exists question_normalized text
+           generated always as (trim(lower(question))) stored;
+
+   alter table public.knowledge_base
+       add constraint knowledge_base_question_key
+           unique (question_normalized);
+   ```
+
+3. **Configurar tus integraciones.** Cuando hagas `upsert` contra el endpoint REST de Supabase, asegúrate de indicar `Prefer: resolution=merge-duplicates` y el conflicto sobre `knowledge_base_question_key`. El helper [`scripts/upsertKnowledgeBase.js`](scripts/upsertKnowledgeBase.js) ya lo hace por ti:
+   ```js
+   import { upsertKnowledgeBase } from './scripts/upsertKnowledgeBase.js';
+
+   await upsertKnowledgeBase({
+     supabaseUrl: process.env.SUPABASE_URL,
+     serviceKey: process.env.SUPABASE_SERVICE_KEY,
+     entry: {
+       question: 'How are you?',
+       answer: 'Great!',
+       metadata: {},
+     },
+   });
+   ```
+
+4. **Compartir la normalización.** Si necesitas normalizar preguntas desde n8n u otros scripts, reutiliza `normalizeQuestion` exportado por el mismo helper para mantener el mismo criterio que la base de datos.
+
+5. **Verificar con tests.** Ejecuta la suite de Node.js para comprobar que el helper sigue apuntando a la constraint correcta:
+   ```bash
+   npm test
+   ```
+
+Con estos pasos podrás reproducir el flujo completo: preparar el esquema, configurar tus integraciones y asegurarte de que los upserts no fallen por constraints ausentes.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "axonic-assistant1",
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/scripts/upsertKnowledgeBase.js
+++ b/scripts/upsertKnowledgeBase.js
@@ -1,0 +1,64 @@
+/**
+ * Upserts a knowledge base entry through the Supabase REST endpoint using the
+ * `knowledge_base_question_key` constraint that normalizes the question text.
+ *
+ * @param {Object} params
+ * @param {string} params.supabaseUrl - The Supabase project URL.
+ * @param {string} params.serviceKey - The service role key used for the request.
+ * @param {{ question: string, answer: string, metadata?: Record<string, any> }} params.entry
+ *   The entry that should be inserted/updated.
+ */
+export async function upsertKnowledgeBase({ supabaseUrl, serviceKey, entry }) {
+  if (!supabaseUrl) {
+    throw new Error('`supabaseUrl` is required');
+  }
+  if (!serviceKey) {
+    throw new Error('`serviceKey` is required');
+  }
+  if (!entry || typeof entry.question !== 'string' || typeof entry.answer !== 'string') {
+    throw new Error('`entry` with `question` and `answer` fields is required');
+  }
+
+  const url = new URL('/rest/v1/knowledge_base', supabaseUrl);
+  url.searchParams.set('on_conflict', 'knowledge_base_question_key');
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+      'Content-Type': 'application/json',
+      Prefer: 'resolution=merge-duplicates,return=representation',
+    },
+    body: JSON.stringify({
+      question: entry.question,
+      answer: entry.answer,
+      metadata: entry.metadata ?? {},
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Supabase knowledge_base upsert failed (${response.status} ${response.statusText}): ${errorText}`,
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Helper that can be used by consumers (such as n8n expressions) to mirror the
+ * database normalization behaviour. Keeping the logic in sync with the
+ * generated column prevents accidental duplicates when comparing input values.
+ *
+ * @param {string} question - Question to normalize.
+ * @returns {string}
+ */
+export function normalizeQuestion(question) {
+  if (typeof question !== 'string') {
+    throw new TypeError('`question` must be a string');
+  }
+
+  return question.trim().toLowerCase();
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,34 @@
+-- Ensure required extensions are available for UUID generation.
+create extension if not exists pgcrypto;
+
+-- Base knowledge base table definition. The unique constraint is declared
+-- separately so that the migration can be reapplied safely.
+create table if not exists public.knowledge_base (
+    id uuid primary key default gen_random_uuid(),
+    question text not null,
+    answer text not null,
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+-- Normalize questions to avoid duplicates caused by casing/whitespace
+-- differences and enforce uniqueness on the normalized value.
+alter table public.knowledge_base
+    add column if not exists question_normalized text
+        generated always as (trim(lower(question))) stored;
+
+do $$
+begin
+    if not exists (
+        select 1
+        from pg_constraint
+        where conrelid = 'public.knowledge_base'::regclass
+          and conname = 'knowledge_base_question_key'
+    ) then
+        alter table public.knowledge_base
+            add constraint knowledge_base_question_key
+                unique (question_normalized);
+    end if;
+end;
+$$;

--- a/tests/upsertKnowledgeBase.test.js
+++ b/tests/upsertKnowledgeBase.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { upsertKnowledgeBase, normalizeQuestion } from '../scripts/upsertKnowledgeBase.js';
+
+test('normalizeQuestion mirrors the database normalization logic', () => {
+  assert.equal(normalizeQuestion('  HELLO World '), 'hello world');
+});
+
+test('upsertKnowledgeBase targets the generated-column constraint', async () => {
+  let capturedUrl;
+  let capturedInit;
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    capturedUrl = url;
+    capturedInit = init;
+    return new Response(JSON.stringify([{ id: '123' }]), {
+      status: 201,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+
+  try {
+    await upsertKnowledgeBase({
+      supabaseUrl: 'https://project.supabase.co',
+      serviceKey: 'service-key',
+      entry: { question: 'How Are You?', answer: 'Great!' },
+    });
+
+    assert.ok(capturedUrl, 'fetch should be called');
+    const url = new URL(capturedUrl);
+    assert.equal(url.pathname, '/rest/v1/knowledge_base');
+    assert.equal(
+      url.searchParams.get('on_conflict'),
+      'knowledge_base_question_key',
+      'Upserts must reference the generated-column constraint',
+    );
+
+    assert.equal(capturedInit.method, 'POST');
+    assert.equal(
+      capturedInit.headers.Prefer,
+      'resolution=merge-duplicates,return=representation',
+      'Prefer header must merge duplicates to trigger the constraint',
+    );
+
+    const body = JSON.parse(capturedInit.body);
+    assert.deepEqual(body, {
+      question: 'How Are You?',
+      answer: 'Great!',
+      metadata: {},
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- add a generated column and uniqueness constraint for normalized questions in the knowledge base schema
- update the knowledge base upsert helper to rely on the new `knowledge_base_question_key` constraint and expose a shared normalizer
- cover the upsert helper with tests that assert the required headers, constraint usage, and normalization logic
- document how to bootstrap the schema and helper usage so contributors know where to start

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dad6e87ce48327b4b303a1be5ed701